### PR TITLE
update the version fo gorilla/websocket to address a vulnerability

### DIFF
--- a/selenium/chrome/devtools/go.mod
+++ b/selenium/chrome/devtools/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/aandryashin/matchers v0.0.0-20161126170413-435295ea180e
 	github.com/google/go-cmp v0.2.0 // indirect
-	github.com/gorilla/websocket v1.4.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/mafredri/cdp v0.23.4
 	golang.org/x/net v0.0.0-20190107210223-45ffb0cd1ba0 // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect


### PR DESCRIPTION
Update the gorilla/websocket version to v1.4.2 to address the vulnerability - https://github.com/gorilla/websocket/security/advisories/GHSA-jf24-p9p9-4rjh

This is addressed in v1.4.1, so updating this to the latest version.