### PR TITLE
Certificates import: Add support of pem keychain with private key

### DIFF
--- a/static/chrome/entrypoint.sh
+++ b/static/chrome/entrypoint.sh
@@ -43,10 +43,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      EMPTY_PASS=\'\'
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
-      echo ${EMPTY_PASS} > /tmp/empty.file
+      PRIVATE_KEY_PASS=${PRIVATE_KEY_PASS:-\'\'}
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${PRIVATE_KEY_PASS} -passin pass:${PRIVATE_KEY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${PRIVATE_KEY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/chrome/entrypoint.sh
+++ b/static/chrome/entrypoint.sh
@@ -41,8 +41,14 @@ if env | grep -q ROOT_CA_; then
   for e in $(env | grep ROOT_CA_ | sed -e 's/=.*$//'); do
     certname=$(echo -n $e | sed -e 's/ROOT_CA_//')
     echo ${!e} | base64 -d >/tmp/cert.pem
-    certutil -A -n ${certname} -t "TCu,Cu,Tu" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
+      AUXILIARY_PASS=123456
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+    fi
     rm /tmp/cert.pem
+    rm /tmp/key.p12
   done
 fi
 

--- a/static/chrome/entrypoint.sh
+++ b/static/chrome/entrypoint.sh
@@ -43,9 +43,10 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      AUXILIARY_PASS=123456
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      EMPTY_PASS=\'\'
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
+      echo ${EMPTY_PASS} > /tmp/empty.file
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/chrome/entrypoint.sh
+++ b/static/chrome/entrypoint.sh
@@ -46,9 +46,9 @@ if env | grep -q ROOT_CA_; then
       AUXILIARY_PASS=123456
       openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
       pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      rm /tmp/key.p12
     fi
     rm /tmp/cert.pem
-    rm /tmp/key.p12
   done
 fi
 

--- a/static/edge/entrypoint.sh
+++ b/static/edge/entrypoint.sh
@@ -38,8 +38,14 @@ if env | grep -q ROOT_CA_; then
   for e in $(env | grep ROOT_CA_ | sed -e 's/=.*$//'); do
     certname=$(echo -n $e | sed -e 's/ROOT_CA_//')
     echo ${!e} | base64 -d >/tmp/cert.pem
-    certutil -A -n ${certname} -t "TCu,Cu,Tu" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
+      AUXILIARY_PASS=123456
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+    fi
     rm /tmp/cert.pem
+    rm /tmp/key.p12
   done
 fi
 

--- a/static/edge/entrypoint.sh
+++ b/static/edge/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      EMPTY_PASS=\'\'
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
+      PRIVATE_KEY_PASS=${PRIVATE_KEY_PASS:-\'\'}
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${PRIVATE_KEY_PASS} -passin pass:${PRIVATE_KEY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${PRIVATE_KEY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/edge/entrypoint.sh
+++ b/static/edge/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      AUXILIARY_PASS=123456
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      EMPTY_PASS=\'\'
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/edge/entrypoint.sh
+++ b/static/edge/entrypoint.sh
@@ -43,9 +43,9 @@ if env | grep -q ROOT_CA_; then
       AUXILIARY_PASS=123456
       openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
       pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      rm /tmp/key.p12
     fi
     rm /tmp/cert.pem
-    rm /tmp/key.p12
   done
 fi
 

--- a/static/firefox/selenoid/entrypoint.sh
+++ b/static/firefox/selenoid/entrypoint.sh
@@ -80,8 +80,14 @@ if env | grep -q ROOT_CA_; then
   for e in $(env | grep ROOT_CA_ | sed -e 's/=.*$//'); do
     certname=$(echo -n $e | sed -e 's/ROOT_CA_//')
     echo ${!e} | base64 -d >/tmp/cert.pem
-    certutil -A -n ${certname} -t "TCu,Cu,Tu" -i /tmp/cert.pem -d sql:${certdir}
+    certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:${certdir}
+    if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
+      AUXILIARY_PASS=123456
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
+      pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+    fi
     rm /tmp/cert.pem
+    rm /tmp/key.p12
   done
 fi
 

--- a/static/firefox/selenoid/entrypoint.sh
+++ b/static/firefox/selenoid/entrypoint.sh
@@ -82,9 +82,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:${certdir}
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      EMPTY_PASS=\'\'
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
-      pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${EMPTY_PASS}
+      PRIVATE_KEY_PASS=${PRIVATE_KEY_PASS:-\'\'}
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${PRIVATE_KEY_PASS}  -passin pass:${PRIVATE_KEY_PASS}
+      pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${PRIVATE_KEY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/firefox/selenoid/entrypoint.sh
+++ b/static/firefox/selenoid/entrypoint.sh
@@ -85,9 +85,9 @@ if env | grep -q ROOT_CA_; then
       AUXILIARY_PASS=123456
       openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
       pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      rm /tmp/key.p12
     fi
     rm /tmp/cert.pem
-    rm /tmp/key.p12
   done
 fi
 

--- a/static/firefox/selenoid/entrypoint.sh
+++ b/static/firefox/selenoid/entrypoint.sh
@@ -82,9 +82,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:${certdir}
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      AUXILIARY_PASS=123456
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
-      pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      EMPTY_PASS=\'\'
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
+      pk12util -d sql:${certdir} -i /tmp/key.p12 -W ${EMPTY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/opera/entrypoint.sh
+++ b/static/opera/entrypoint.sh
@@ -38,8 +38,14 @@ if env | grep -q ROOT_CA_; then
   for e in $(env | grep ROOT_CA_ | sed -e 's/=.*$//'); do
     certname=$(echo -n $e | sed -e 's/ROOT_CA_//')
     echo ${!e} | base64 -d >/tmp/cert.pem
-    certutil -A -n ${certname} -t "TCu,Cu,Tu" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
+      AUXILIARY_PASS=123456
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+    fi
     rm /tmp/cert.pem
+    rm /tmp/key.p12
   done
 fi
 

--- a/static/opera/entrypoint.sh
+++ b/static/opera/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      EMPTY_PASS=\'\'
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
+      PRIVATE_KEY_PASS=${PRIVATE_KEY_PASS:-\'\'}
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${PRIVATE_KEY_PASS} -passin pass:${PRIVATE_KEY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${PRIVATE_KEY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/opera/entrypoint.sh
+++ b/static/opera/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      AUXILIARY_PASS=123456
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      EMPTY_PASS=\'\'
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/opera/entrypoint.sh
+++ b/static/opera/entrypoint.sh
@@ -43,9 +43,9 @@ if env | grep -q ROOT_CA_; then
       AUXILIARY_PASS=123456
       openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
       pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      rm /tmp/key.p12
     fi
     rm /tmp/cert.pem
-    rm /tmp/key.p12
   done
 fi
 

--- a/static/yandex/entrypoint.sh
+++ b/static/yandex/entrypoint.sh
@@ -38,8 +38,14 @@ if env | grep -q ROOT_CA_; then
   for e in $(env | grep ROOT_CA_ | sed -e 's/=.*$//'); do
     certname=$(echo -n $e | sed -e 's/ROOT_CA_//')
     echo ${!e} | base64 -d >/tmp/cert.pem
-    certutil -A -n ${certname} -t "TCu,Cu,Tu" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
+    if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
+      AUXILIARY_PASS=123456
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+    fi
     rm /tmp/cert.pem
+    rm /tmp/key.p12
   done
 fi
 

--- a/static/yandex/entrypoint.sh
+++ b/static/yandex/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      EMPTY_PASS=\'\'
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
+      PRIVATE_KEY_PASS=${PRIVATE_KEY_PASS:-\'\'}
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${PRIVATE_KEY_PASS} -passin pass:${PRIVATE_KEY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${PRIVATE_KEY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/yandex/entrypoint.sh
+++ b/static/yandex/entrypoint.sh
@@ -40,9 +40,9 @@ if env | grep -q ROOT_CA_; then
     echo ${!e} | base64 -d >/tmp/cert.pem
     certutil -A -n ${certname} -t "TC,C,T" -i /tmp/cert.pem -d sql:$HOME/.pki/nssdb
     if cat tmp/cert.pem | grep -q "PRIVATE KEY"; then
-      AUXILIARY_PASS=123456
-      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
-      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      EMPTY_PASS=\'\'
+      openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${EMPTY_PASS}
+      pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${EMPTY_PASS}
       rm /tmp/key.p12
     fi
     rm /tmp/cert.pem

--- a/static/yandex/entrypoint.sh
+++ b/static/yandex/entrypoint.sh
@@ -43,9 +43,9 @@ if env | grep -q ROOT_CA_; then
       AUXILIARY_PASS=123456
       openssl pkcs12 -export -in /tmp/cert.pem -clcerts -nodes -out /tmp/key.p12 -passout pass:${AUXILIARY_PASS}
       pk12util -d sql:$HOME/.pki/nssdb -i /tmp/key.p12 -W ${AUXILIARY_PASS}
+      rm /tmp/key.p12
     fi
     rm /tmp/cert.pem
-    rm /tmp/key.p12
   done
 fi
 


### PR DESCRIPTION
Private key sometimes required for authentication in web resources across enterprise networks.
 
Currently import of the pem file content support certificates only, ignoring any private key, associated with user certificate.
The reason of that behavior is lack of private keys support in _certutil_. Consequently, trustargs **TCu,Cu,Tu** for the certificate are useless (**TC,C,T** only supported).

Provided solution resolves the issue with steps:

1. export **ca and client certs** from pem file to nss db with _certutil_ 
2. convert **client cert with associated private key** from pem format to p12 format
3. export **private key** to  nss db with _pk12util_

Such 3-steps export provides ability to migrate all certs and keys from pem file to nss db.
