### PR TITLE
Renamed deprecated ChromeDriver command line option

### DIFF
--- a/static/chrome/entrypoint.sh
+++ b/static/chrome/entrypoint.sh
@@ -87,7 +87,7 @@ if [ "$ENABLE_VNC" == "true" ]; then
     X11VNC_PID=$!
 fi
 
-DISPLAY="$DISPLAY" /usr/bin/chromedriver --port=4444 --whitelisted-ips='' ${DRIVER_ARGS} &
+DISPLAY="$DISPLAY" /usr/bin/chromedriver --port=4444 --allowed-ips='' ${DRIVER_ARGS} &
 DRIVER_PID=$!
 
 wait

--- a/static/yandex/entrypoint.sh
+++ b/static/yandex/entrypoint.sh
@@ -79,7 +79,7 @@ if [ "$ENABLE_VNC" == "true" ]; then
     X11VNC_PID=$!
 fi
 
-DISPLAY="$DISPLAY" /usr/bin/yandexdriver --port=4444 --whitelisted-ips='' ${DRIVER_ARGS} &
+DISPLAY="$DISPLAY" /usr/bin/yandexdriver --port=4444 --allowed-ips='' ${DRIVER_ARGS} &
 DRIVER_PID=$!
 
 wait


### PR DESCRIPTION
`--whitelisted-ips` was renamed to `--allowed-ips` since ChromeDriver 87.0.4280.20
https://chromedriver.storage.googleapis.com/87.0.4280.20/notes.txt 