### PR TITLE
Support devtools and custom profile directory for Chrome via environment variable

### DIFF
--- a/docs/features.adoc
+++ b/docs/features.adoc
@@ -24,3 +24,25 @@ In that case `<cert-name>` will be used as certificate name in the browser certi
 
     ROOT_CA_MY_CERT="LS0tL....=="
 
+=== Using Custom Browser Profile with Chrome
+
+If launching Chrome with a custom profile directory, Devtools will not work unless you
+also set the `BROWSER_PROFILE_DIR` environment variable. _E.g._ when requesting the session:
+
+[source,json]
+----
+{
+  "capabilities": {
+    "alwaysMatch": {
+      "browserName": "chrome",
+      "browserVersion": "114.0",
+      "goog:chromeOptions": {
+        "args": [ "user-data-dir=/profiles/custom.XYZ" ]
+      },
+      "selenoid:options": {
+        "env": [ "BROWSER_PROFILE_DIR=/profiles/custom.XYZ" ]
+      }
+    }
+  }
+}
+----

--- a/static/chrome/devtools/devtools.go
+++ b/static/chrome/devtools/devtools.go
@@ -153,13 +153,19 @@ func androidDevtoolsHost() (string, error) {
 
 func detectDevtoolsHost(baseDir string) string {
 	var candidates []string
-	for _, glob := range []string{".com.google.Chrome*", ".org.chromium.Chromium*"} {
-		cds, err := filepath.Glob(filepath.Join(baseDir, glob))
-		if err == nil {
-			candidates = append(candidates, cds...)
-		}
 
+	pd, found := os.LookupEnv("BROWSER_PROFILE_DIR")
+	if found {
+		candidates = append(candidates, pd)
+	} else {
+		for _, glob := range []string{".com.google.Chrome*", ".org.chromium.Chromium*"} {
+			cds, err := filepath.Glob(filepath.Join(baseDir, glob))
+			if err == nil {
+				candidates = append(candidates, cds...)
+			}
+		}
 	}
+
 	for _, c := range candidates {
 		f, err := os.Stat(c)
 		if err != nil {

--- a/static/chrome/devtools/devtools_test.go
+++ b/static/chrome/devtools/devtools_test.go
@@ -174,3 +174,15 @@ func TestDetectDevtoolsHost(t *testing.T) {
 
 	AssertThat(t, detectDevtoolsHost(name), EqualTo{"127.0.0.1:12345"})
 }
+
+func TestDetectDevtoolsHostProfileDir(t *testing.T) {
+	name, _ := ioutil.TempDir("", "devtools")
+	defer os.RemoveAll(name)
+	profilePath := filepath.Join(name, "can_be_anything")
+	os.MkdirAll(profilePath, os.ModePerm)
+	portFile := filepath.Join(profilePath, "DevToolsActivePort")
+	ioutil.WriteFile(portFile, []byte("12345\n/devtools/browser/6f37c7fe-a0a6-4346-a6e2-80c5da0687f0"), 0644)
+
+	t.Setenv("BROWSER_PROFILE_DIR", profilePath)
+	AssertThat(t, detectDevtoolsHost(name), EqualTo{"127.0.0.1:12345"})
+}


### PR DESCRIPTION
Offers a solution for https://github.com/aerokube/images/issues/627.

With this change you can set `BROWSER_PROFILE_DIR` in the container environment and the devtools proxy process will use that location when looking for the browser profile. _E.g._:

```
{
  "capabilities": {
    "alwaysMatch": {
      "browserName": "chrome",
      "browserVersion": "114.0",
      "goog:chromeOptions": {
        "args": [ "user-data-dir=/profiles/custom.XYZ" ]
      },
      "selenoid:options": {
        "env": [ "BROWSER_PROFILE_DIR=/profiles/custom.XYZ" ]
      }
    }
  }
}
```

