### PR TITLE
Fix: Update file to support Appium 2 when building new image

### DIFF
--- a/selenium/android/Dockerfile
+++ b/selenium/android/Dockerfile
@@ -4,7 +4,9 @@ COPY tmp/devtools /devtools
 
 RUN \
     apt-get update && \
-    apt-get install -y upx-ucl libx11-dev && \
+    wget -c http://ftp.us.debian.org/debian/pool/main/u/upx-ucl/upx-ucl_3.95-1_amd64.deb && \
+    apt-get install -y ./upx-ucl_3.95-1_amd64.deb && \
+    apt-get install -y libx11-dev && \
     cd /devtools && \
     GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" && \
     upx /devtools/devtools
@@ -38,7 +40,10 @@ RUN \
     apt-get clean && \
     rm -Rf /tmp/* && rm -Rf /var/lib/apt/lists/*
 
-RUN cd / && npm install --prefix ./opt/ appium@$APPIUM_VERSION
+RUN \
+    cd / && \
+    npm install --prefix ./opt/ appium@$APPIUM_VERSION && \
+    /opt/node_modules/.bin/appium driver install uiautomator2
 
 COPY android.conf /etc/ld.so.conf.d/
 COPY fluxbox/aerokube /usr/share/fluxbox/styles/

--- a/selenium/android/entrypoint.sh
+++ b/selenium/android/entrypoint.sh
@@ -70,7 +70,8 @@ fi
 while [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ] && [ -z "$STOP" ] ; do sleep 1; done
 if [ -n "$STOP" ]; then exit 0; fi
 
-DEFAULT_CAPABILITIES='"androidNaturalOrientation": true, "deviceName": "android", "platformName": "Android", "noReset": true, "udid":"'$EMULATOR'"'
+DEFAULT_CAPABILITIES='"appium:androidNaturalOrientation": true, "appium:deviceName": "android", "platformName": "Android", "appium:automationName": "UiAutomator2", "appium:noReset": true, "appium:udid": "'$EMULATOR'", "appium:systemPort": '$BOOTSTRAP_PORT', "appium:newCommandTimeout": 90'
+
 if [ -n "@CHROME_MOBILE@" ]; then
     while ip addr | grep inet | grep -q tentative > /dev/null; do sleep 0.1; done
     DEFAULT_CAPABILITIES=$DEFAULT_CAPABILITIES', "chromedriverPort": '$CHROMEDRIVER_PORT
@@ -82,7 +83,7 @@ if [ -x "/usr/bin/chromedriver" ]; then
     DEFAULT_CAPABILITIES=$DEFAULT_CAPABILITIES',"chromedriverExecutable": "/usr/bin/chromedriver"'
 fi
 
-/opt/node_modules/.bin/appium -a 0.0.0.0 -p "$PORT" -bp "$BOOTSTRAP_PORT" --log-timestamp --log-no-colors --command-timeout 90 --no-reset ${APPIUM_ARGS} --default-capabilities "{$DEFAULT_CAPABILITIES}" &
+/opt/node_modules/.bin/appium -a 0.0.0.0 -p "$PORT" --log-timestamp --log-no-colors ${APPIUM_ARGS} --base-path "/wd/hub" --default-capabilities "{$DEFAULT_CAPABILITIES}" &
 APPIUM_PID=$!
 
 wait


### PR DESCRIPTION
Support Appium 2 when building new image:
- Update entrypoint.sh:
  - Fix upx-ucl.
  - Add download driver uiautomator2 with npm.
- Update Dockerfile:
  - Fix DEFAULT_CAPABILITIES to support 2.0.
  - Appium attributes to support 2.0.